### PR TITLE
Potential fix for code scanning alert no. 26: Server-side request forgery

### DIFF
--- a/apps/studio/pages/api/edge-functions/test.ts
+++ b/apps/studio/pages/api/edge-functions/test.ts
@@ -19,15 +19,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 
 async function handlePost(req: NextApiRequest, res: NextApiResponse) {
+  // Allow-list of permitted edge function names and their URLs
+  const EDGE_FUNCTION_URLS: Record<string, string> = {
+    // Example: 'myFunction': 'https://<project-ref>.functions.supabase.co/myFunction'
+    // Add allowed function names and their URLs here
+  }
   try {
-    const { url, method, body: requestBody, headers: customHeaders } = req.body
+    const { functionName, method, body: requestBody, headers: customHeaders } = req.body
 
-    const validEdgeFnUrl = isValidEdgeFunctionURL(url)
+    const url = EDGE_FUNCTION_URLS[functionName]
 
-    if (!validEdgeFnUrl) {
+    if (!url) {
       return res.status(400).json({
         status: 400,
-        error: { message: 'Provided URL is not a valid Supabase edge function URL' },
+        error: { message: 'Provided functionName is not allowed or does not exist' },
       })
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/supabase/security/code-scanning/26](https://github.com/akadevbarki76-collab/supabase/security/code-scanning/26)

To fix the SSRF vulnerability, we must ensure that the `url` used in the `fetch` call cannot be controlled by the user in a way that allows requests to arbitrary or internal endpoints. The best way to do this is to replace the direct use of the user-provided `url` with a value selected from a strict allow-list of known, safe endpoints. Alternatively, if the user is allowed to select from a set of edge functions, the request should only use a server-side mapping from a user-supplied identifier (e.g., function name) to a known, safe URL.

**Detailed fix:**  
- Instead of accepting a full URL from the user, accept a function identifier (e.g., `functionName`).
- Maintain a server-side allow-list (object or array) mapping allowed function names to their corresponding URLs.
- When handling the request, look up the URL from the allow-list using the provided function name.
- Only proceed with the fetch if the function name is valid and mapped to a known URL.
- Remove or ignore the user-supplied `url` field.

**Required changes:**  
- Change the destructuring in line 23 to accept `functionName` instead of `url`.
- Add a mapping of allowed function names to URLs at the top of the file or within the handler.
- Replace all uses of `url` with the looked-up URL from the allow-list.
- Remove the call to `isValidEdgeFunctionURL` (or keep it only if it is used as a secondary check).
- Return an error if the function name is not in the allow-list.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
