### PR TITLE
Potential fix for code scanning alert no. 25: Server-side request forgery

### DIFF
--- a/apps/studio/pages/api/edge-functions/body.ts
+++ b/apps/studio/pages/api/edge-functions/body.ts
@@ -29,6 +29,14 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     if (!slug) {
       return res.status(400).json({ error: 'slug is required' })
     }
+    // Validate projectRef and slug to prevent SSRF and path traversal
+    const safePattern = /^[a-zA-Z0-9_-]+$/
+    if (!safePattern.test(projectRef)) {
+      return res.status(400).json({ error: 'Invalid projectRef format' })
+    }
+    if (!safePattern.test(slug)) {
+      return res.status(400).json({ error: 'Invalid slug format' })
+    }
 
     // Get authorization token from the request
     const authToken = req.headers.authorization


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/supabase/security/code-scanning/25](https://github.com/akadevbarki76-collab/supabase/security/code-scanning/25)

To fix the SSRF vulnerability, we should validate and sanitize the user-provided `projectRef` and `slug` before using them in the URL. The best approach is to restrict these values to a safe format, such as allowing only alphanumeric characters, dashes, and underscores (which are typical for slugs and project references). This prevents path traversal and other malicious input. The validation should occur immediately after extracting the values from `req.body`, and the request should be rejected with a 400 error if the values do not match the expected pattern.

**Required changes:**
- Add validation for `projectRef` and `slug` in the `handlePost` function, after extracting them from `req.body`.
- Use a regular expression to ensure both values only contain allowed characters (e.g., `/^[a-zA-Z0-9_-]+$/`).
- If validation fails, return a 400 error with an appropriate message.
- No new methods or imports are required, as JavaScript's built-in RegExp is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
